### PR TITLE
Hiding jar process window

### DIFF
--- a/kbm-robot.js
+++ b/kbm-robot.js
@@ -234,7 +234,7 @@ function kbmRobot() {
                     throw new Error("ERR: Can't find robot" + JRE_ver +
                         ".jar. Expected Path: " + jarPath);
                 }
-                keyPresser = spawn("java", ["-jar", jarPath]);
+                keyPresser = spawn("java", ["-jar", jarPath], {windowsHide:true});
 
                 // Need to hook up these handlers to prevent the
                 // jar from crashing sometimes.


### PR DESCRIPTION
On windows, when using a node process manager like PM2, a window is opened when calling `startJar()`.
The update takes advantage of the `windowsHide` flag to avoid that.